### PR TITLE
Temp fix for some universities not having userName field

### DIFF
--- a/blackboard_sync/blackboard/api.py
+++ b/blackboard_sync/blackboard/api.py
@@ -123,8 +123,7 @@ class BlackboardSession:
     def username(self) -> str:
         """Username field used for API requests."""
         if self._username is None:
-            username = self.fetch_users(user_id='me')['userName']
-            self._username = f'userName:{username}'
+            self._username = self.fetch_users(user_id='me')['id']
         return self._username
 
     @property


### PR DESCRIPTION
As suggested by @ziyuanding the userName field can be replaced by the user id for now to allow new universities to be supported, including University of Western Australia and University of Aberdeen.