### PR TITLE
Path naming fix

### DIFF
--- a/blackboard_sync/content/content.py
+++ b/blackboard_sync/content/content.py
@@ -31,14 +31,6 @@ class Content:
         self.ignore = not Content.should_download(content, job)
         self.is_ultra_document_body = content.title == "ultraDocumentBody"
 
-
-        try:
-            if content.body:
-                self.body = body.ContentBody(content, None, job)
-        except (ValidationError, JSONDecodeError,
-                BBBadRequestError, BBForbiddenError, RequestException):
-            logger.warning(f"Error fetching body of {content.title}")
-
         if self.ignore:
             return
 
@@ -52,22 +44,30 @@ class Content:
                 BBBadRequestError, BBForbiddenError, RequestException):
             logger.exception(f"Error fetching {content.title}")
 
+        try:
+            if content.body:
+                self.body = body.ContentBody(content, None, job)
+        except (ValidationError, JSONDecodeError,
+                BBBadRequestError, BBForbiddenError, RequestException):
+            logger.warning(f"Error fetching body of {content.title}")
+
+
     def write(self, path: Path, executor: ThreadPoolExecutor):
-        if self.ignore and not self.is_ultra_document_body:
-            return
+            if self.ignore and not self.is_ultra_document_body:
+                return
 
-        # Build nested path with content title
-        path = path / self.title if not self.is_ultra_document_body else path
+            # Build nested path with content title
+            path = path / self.title if not self.is_ultra_document_body else path
 
-        if self.handler is not None:
-            if self.handler.create_dir:
+            if self.handler is not None:
+                if self.handler.create_dir:
+                    path.mkdir(exist_ok=True, parents=True)
+
+                self.handler.write(path, executor)
+
+            if self.body is not None:
                 path.mkdir(exist_ok=True, parents=True)
-
-            self.handler.write(path, executor)
-
-        if self.body is not None:
-            path.mkdir(exist_ok=True, parents=True)
-            self.body.write(path, executor)
+                self.body.write(path, executor)
 
     @staticmethod
     def should_download(content: BBCourseContent, job: DownloadJob):

--- a/blackboard_sync/content/content.py
+++ b/blackboard_sync/content/content.py
@@ -53,21 +53,21 @@ class Content:
 
 
     def write(self, path: Path, executor: ThreadPoolExecutor):
-            if self.ignore and not self.is_ultra_document_body:
-                return
+        if self.ignore and not self.is_ultra_document_body:
+            return
 
-            # Build nested path with content title
-            path = path / self.title if not self.is_ultra_document_body else path
+        # Build nested path with content title
+        path = path / self.title if not self.is_ultra_document_body else path
 
-            if self.handler is not None:
-                if self.handler.create_dir:
-                    path.mkdir(exist_ok=True, parents=True)
-
-                self.handler.write(path, executor)
-
-            if self.body is not None:
+        if self.handler is not None:
+            if self.handler.create_dir:
                 path.mkdir(exist_ok=True, parents=True)
-                self.body.write(path, executor)
+
+            self.handler.write(path, executor)
+
+        if self.body is not None:
+            path.mkdir(exist_ok=True, parents=True)
+            self.body.write(path, executor)
 
     @staticmethod
     def should_download(content: BBCourseContent, job: DownloadJob):


### PR DESCRIPTION
The previous body processing issue was simply to do with the config file (I figured after an hour or two). After deleting it everything began to redownload as expected.

The only other issue I had left was that some files stored in the ultraDocumentBody had them stored under an extra, unnecessary directory titled "ultraDocumentBody". These changes seem to fix that. This may not be the optimal implementation, however it seems simple and works for me.

Line 56, the handling of the ignoring in the write content method, may also not need the is_ultra flag, however after checking out the directory it seems to work well with it there, hence I haven't removed it.