### PR TITLE
Support x-bb-assignment as Document content handler

### DIFF
--- a/blackboard_sync/content/content.py
+++ b/blackboard_sync/content/content.py
@@ -83,6 +83,8 @@ class Content:
                 return folder.Folder
             case BBResourceType.File | BBResourceType.Document:
                 return document.Document
+            case BBResourceType.Assignment:
+                return document.Document
             case BBResourceType.ExternalLink:
                 return externallink.ExternalLink
             case _:


### PR DESCRIPTION
As a classic assignment (x-bb-assignment) supports attachments, this code will treat assignments as documents and handle them with the Document handler class, which hopefully means that assignment attachments get downloaded as one would expect.