### PR TITLE
Avoid filename conflicts with content and attachments, handle oserror

### DIFF
--- a/blackboard_sync/content/content.py
+++ b/blackboard_sync/content/content.py
@@ -38,7 +38,7 @@ class Content:
 
         Handler = Content.get_handler(content.contentHandler)
 
-        self.title = content.title_path_safe
+        self.title = content.title_path_safe.replace('.', '_')
 
         try:
             self.handler = Handler(content, api_path, job)

--- a/blackboard_sync/sync.py
+++ b/blackboard_sync/sync.py
@@ -154,8 +154,8 @@ class BlackboardSync:
         except BBUnauthorizedError:
             logger.exception("User session expired")
             self.log_out()
-        except RequestException:
-            logger.exception("Network failure")
+        except (RequestException, OSError):
+            logger.exception("Download error")
             self._has_error = True
 
             # manually postpone next sync job


### PR DESCRIPTION
With these changes the file extension will be guessed from the mimetype property found in the BBAttachment object.
If the filename already has a valid extension for the mimetype then it won't be appended.

OSError happening in the thread pool executor is now handled and the user is informed of this. The download will not count as complete.

Closes #384 