### PR TITLE
Add timestamps to downloaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for Syracuse University (@363843342)
 - Add support for University of Illinois Chicago (@hoangngo-sudo)
 - Add support for Università Bocconi (@giuliofrey)
+- Timestamps are now added to the files downloaded
 
 ## [0.18.0] - 2024-10-22
 

--- a/blackboard_sync/content/attachment.py
+++ b/blackboard_sync/content/attachment.py
@@ -1,5 +1,6 @@
 import uuid
 import mimetypes
+from datetime import datetime
 
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
@@ -14,8 +15,13 @@ from .job import DownloadJob
 class Attachment(BStream):
     """File attached to a content."""
 
-    def __init__(self, attachment: BBAttachment, api_path: BBContentPath,
-                 job: DownloadJob):
+    def __init__(
+        self,
+        attachment: BBAttachment,
+        api_path: BBContentPath,
+        job: DownloadJob,
+        modified_time: datetime | None = None,
+    ) -> None:
         filename = attachment.fileName or str(uuid.uuid1())
         name_ext = '.' + filename.split('.')[-1]
 
@@ -28,6 +34,8 @@ class Attachment(BStream):
         else:
             real_ext = possible_ext[0] if possible_ext else '.txt'
             self.filename = filename + real_ext
+
+        self.modified_time = modified_time
 
         self.stream = job.session.download(attachment_id=attachment.id,
                                            **api_path)

--- a/blackboard_sync/content/base.py
+++ b/blackboard_sync/content/base.py
@@ -1,3 +1,5 @@
+import os
+from datetime import datetime
 from pathlib import Path
 from requests import Response
 
@@ -8,14 +10,23 @@ class BStream:
     """Base class for content that can be downloaded as a byte stream."""
     CHUNK_SIZE = 1024
 
-    def write_base(self, path: Path, executor: ThreadPoolExecutor,
-                   stream: Response) -> None:
+    def write_base(
+        self,
+        path: Path,
+        executor: ThreadPoolExecutor,
+        stream: Response,
+        modified_time: datetime | None = None
+    ) -> None:
         """Schedule the write operation."""
 
         def _write() -> None:
             with path.open("wb") as f:
                 for chunk in stream.iter_content(chunk_size=self.CHUNK_SIZE):
                     f.write(chunk)
+
+            if modified_time is not None:
+                timestamp = modified_time.timestamp()
+                os.utime(path, (timestamp, timestamp))
 
         executor.submit(_write)
 

--- a/blackboard_sync/content/document.py
+++ b/blackboard_sync/content/document.py
@@ -24,7 +24,9 @@ class Document:
 
         for i, attachment in enumerate(filtered_attachments):
             self.attachments.append(
-                Attachment(attachment, api_path, job)
+                Attachment(
+                    attachment, api_path, job, modified_time=content.modified
+                )
             )
 
     def write(self, path: Path, executor: ThreadPoolExecutor) -> None:


### PR DESCRIPTION
Set downloaded files' modified time from API

- Pass BBCourseContent.modified timestamp through download hierarchy
- Apply timestamp using os.utime() after file writes

This change preserves the content modification times reported by the Blackboard API instead of using local download time. Files will now show their actual last updated time from the learning platform.

Affected components:
- content/document.py
- content/attachment.py
- content/base.py

Close #486 

