### PR TITLE
Close stream socket on error

### DIFF
--- a/blackboard_sync/content/attachment.py
+++ b/blackboard_sync/content/attachment.py
@@ -29,8 +29,19 @@ class Attachment(BStream):
             real_ext = possible_ext[0] if possible_ext else '.txt'
             self.filename = filename + real_ext
 
-        self.stream = job.session.download(attachment_id=attachment.id,
-                                           **api_path)
+        # Store download parameters; defer opening the connection until write()
+        self._session = job.session
+        self._attachment_id = attachment.id
+        self._api_path = api_path
 
     def write(self, path: Path, executor: ThreadPoolExecutor) -> None:
-        super().write_base(path / self.filename, executor, self.stream)
+        session = self._session
+        attachment_id = self._attachment_id
+        api_path = self._api_path
+        filepath = path / self.filename
+
+        def _download_and_write() -> None:
+            stream = session.download(attachment_id=attachment_id, **api_path)
+            BStream._write_stream(filepath, stream)
+
+        executor.submit(_download_and_write)

--- a/blackboard_sync/content/base.py
+++ b/blackboard_sync/content/base.py
@@ -8,16 +8,21 @@ class BStream:
     """Base class for content that can be downloaded as a byte stream."""
     CHUNK_SIZE = 1024
 
+    @staticmethod
+    def _write_stream(path: Path, stream: Response,
+                      chunk_size: int = CHUNK_SIZE) -> None:
+        """Write a streaming response to disk, always closing the stream."""
+        try:
+            with path.open("wb") as f:
+                for chunk in stream.iter_content(chunk_size=chunk_size):
+                    f.write(chunk)
+        finally:
+            stream.close()
+
     def write_base(self, path: Path, executor: ThreadPoolExecutor,
                    stream: Response) -> None:
         """Schedule the write operation."""
-
-        def _write() -> None:
-            with path.open("wb") as f:
-                for chunk in stream.iter_content(chunk_size=self.CHUNK_SIZE):
-                    f.write(chunk)
-
-        executor.submit(_write)
+        executor.submit(BStream._write_stream, path, stream, self.CHUNK_SIZE)
 
 
 class FStream:

--- a/blackboard_sync/content/webdav.py
+++ b/blackboard_sync/content/webdav.py
@@ -107,17 +107,32 @@ class WebDavFile(BStream):
     """A Blackboard WebDav file which can be downloaded directly"""
     def __init__(self, link: Link, job: DownloadJob) -> None:
         self.title = sanitize_filename(link.text, replacement_text="_")
-        self.stream = job.session.download_webdav(webdav_url=link.href)
-        content_type = self.stream.headers.get('Content-Type', 'text/plain')
-        self.extension = mimetypes.guess_extension(content_type)
-        self.valid = validate_webdav_response(self.stream, link.href,
-                                              job.session.instance_url)
+        # Store download parameters; defer opening the connection until write()
+        self._session = job.session
+        self._link = link
 
     def write(self, path: Path, executor: ThreadPoolExecutor) -> None:
-        if self.valid:
-            path = Path(path, self.title)
+        session = self._session
+        link = self._link
+        title = self.title
 
-            if self.extension:
-                path = path.with_suffix(self.extension)
+        def _download_and_write() -> None:
+            stream = session.download_webdav(webdav_url=link.href)
+            try:
+                content_type = stream.headers.get('Content-Type', 'text/plain')
+                extension = mimetypes.guess_extension(content_type)
+                valid = validate_webdav_response(stream, link.href,
+                                                 session.instance_url)
+                if not valid:
+                    return
 
-            super().write_base(path, executor, self.stream)
+                dest = Path(path, title)
+                if extension:
+                    dest = dest.with_suffix(extension)
+
+                BStream._write_stream(dest, stream)
+            finally:
+                # Necessary because BStream._write_stream does not handle case when valid==False
+                stream.close() 
+
+        executor.submit(_download_and_write)


### PR DESCRIPTION
Fixes #685

Summary of changes: when downloading a resource through a stream, the sockets are now closed on error. Additionally, it is possible that previously streams were not closed even without an error; in any case, that is no longer an issue either.

Tested working. Generated with github copilot, but I manually reviewed the changes.